### PR TITLE
linux-variscite: Fix SRCREV_FORMAT

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -2,7 +2,7 @@
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRCREV_FORMAT = "linux-firmware"
+SRCREV_FORMAT = "brcm_tiwlan_tibt"
 
 SRCREV_brcm = "8081cd2bddb1569abe91eb50bd687a2066a33342"
 BRANCH_brcm = "8.2.0.16"


### PR DESCRIPTION
The SRCREV_FORMAT variable should contain the names from the SRC_URI
for named git repos. Setting it to an invalid value can lead to
incorrect matching of variables such as SRCREV to repos.