### PR TITLE
linux-variscite: update to latest

### DIFF
--- a/recipes-kernel/linux/linux-common.inc
+++ b/recipes-kernel/linux/linux-common.inc
@@ -1,4 +1,4 @@
-LINUX_VERSION = "5.4.127"
-SRCBRANCH = "5.4-2.3.x-imx_var01"
-SRCREV = "c741752b0c7c672ea057cd4059498b13e1f063bf"
+LINUX_VERSION = "5.4.142"
+SRCBRANCH = "5.4-2.1.x-imx_var01"
+SRCREV = "a6e421180801d026531a46d0b4dfebcb18a2870b"
 KERNEL_SRC = "git://github.com/varigit/linux-imx;protocol=https"


### PR DESCRIPTION
Taking latest kernel from dunfell branch:
 5.4.127 -> 5.4.142